### PR TITLE
Enhance factory usage charts with grouping and bar toggle

### DIFF
--- a/BlockViz.Application/Models/OxyColorExtensions.cs
+++ b/BlockViz.Application/Models/OxyColorExtensions.cs
@@ -1,12 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.Windows.Media;
+using OxyPlot;
 
 namespace BlockViz.Applications.Models
 {
-    internal class OxyColorExtensions
+    public static class OxyColorExtensions
     {
+        public static OxyColor ToOxyColor(this Color color)
+        {
+            return OxyColor.FromArgb(color.A, color.R, color.G, color.B);
+        }
     }
 }

--- a/BlockViz.Application/Models/PieOptions.cs
+++ b/BlockViz.Application/Models/PieOptions.cs
@@ -1,12 +1,105 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.ComponentModel;
 
 namespace BlockViz.Applications.Models
 {
-    internal class PieOptions
+    public enum LabelMode
     {
+        PercentOnly,
+        Off
+    }
+
+    /// <summary>
+    /// Options controlling the pie/bar charts in PiView.
+    /// </summary>
+    public class PieOptions : INotifyPropertyChanged
+    {
+        private double smallSliceThreshold = 0.05;
+        private int maxSlices = 12;
+        private int topN = 6;
+        private double innerDiameter = 0.55;
+        private LabelMode labelMode = LabelMode.PercentOnly;
+        private bool useBarChart;
+
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        public double SmallSliceThreshold
+        {
+            get => smallSliceThreshold;
+            set
+            {
+                if (smallSliceThreshold != value)
+                {
+                    smallSliceThreshold = value;
+                    OnPropertyChanged(nameof(SmallSliceThreshold));
+                }
+            }
+        }
+
+        public int MaxSlices
+        {
+            get => maxSlices;
+            set
+            {
+                if (maxSlices != value)
+                {
+                    maxSlices = value;
+                    OnPropertyChanged(nameof(MaxSlices));
+                }
+            }
+        }
+
+        public int TopN
+        {
+            get => topN;
+            set
+            {
+                if (topN != value)
+                {
+                    topN = value;
+                    OnPropertyChanged(nameof(TopN));
+                }
+            }
+        }
+
+        public double InnerDiameter
+        {
+            get => innerDiameter;
+            set
+            {
+                if (innerDiameter != value)
+                {
+                    innerDiameter = value;
+                    OnPropertyChanged(nameof(InnerDiameter));
+                }
+            }
+        }
+
+        public LabelMode LabelMode
+        {
+            get => labelMode;
+            set
+            {
+                if (labelMode != value)
+                {
+                    labelMode = value;
+                    OnPropertyChanged(nameof(LabelMode));
+                }
+            }
+        }
+
+        public bool UseBarChart
+        {
+            get => useBarChart;
+            set
+            {
+                if (useBarChart != value)
+                {
+                    useBarChart = value;
+                    OnPropertyChanged(nameof(UseBarChart));
+                }
+            }
+        }
+
+        private void OnPropertyChanged(string name) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
     }
 }

--- a/BlockViz.Application/ViewModels/PiViewModel.cs
+++ b/BlockViz.Application/ViewModels/PiViewModel.cs
@@ -1,127 +1,172 @@
-﻿// ✅ 수정된 PiViewModel.cs - BlockName 기준 고정 색상 적용
 using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.ComponentModel.Composition;
-using System.Collections.ObjectModel;
 using System.Linq;
-using BlockViz.Applications.Services;
+using System.Text.RegularExpressions;
+using System.Timers;
+using BlockViz.Applications.Helpers;
+using BlockViz.Applications.Models;
 using BlockViz.Applications.Views;
+using BlockViz.Domain.Models;
 using OxyPlot;
+using OxyPlot.Axes;
+using OxyPlot.Legends;
 using OxyPlot.Series;
 using System.Waf.Applications;
-using System.Collections.Generic;
 
 namespace BlockViz.Applications.ViewModels
 {
     [Export]
-    public class PiViewModel : ViewModel<IPiView>, INotifyPropertyChanged
+    public class PiViewModel : ViewModel<IPiView>
     {
-        private readonly IScheduleService scheduleService;
-        private readonly SimulationService simulationService;
-        private readonly Dictionary<string, OxyColor> colorMap = new();
-        private readonly OxyColor[] palette = new[]
-        {
-            OxyColors.Red, OxyColors.Orange, OxyColors.Yellow,
-            OxyColors.LimeGreen, OxyColors.SkyBlue, OxyColors.Purple,
-            OxyColors.Brown, OxyColors.Teal, OxyColors.Pink
-        };
+        private readonly List<Block> blocks = new();
+        private readonly Timer rebuildTimer = new(100) { AutoReset = false };
 
-        public event PropertyChangedEventHandler PropertyChanged;
         public ObservableCollection<PlotModel> PieModels { get; }
+        public PieOptions Options { get; }
 
         [ImportingConstructor]
-        public PiViewModel(IPiView view,
-                           IScheduleService scheduleService,
-                           SimulationService simulationService) : base(view)
+        public PiViewModel(IPiView view) : base(view)
         {
-            this.scheduleService = scheduleService;
-            this.simulationService = simulationService;
-
             PieModels = new ObservableCollection<PlotModel>();
-            simulationService.PropertyChanged += (s, e) =>
-            {
-                if (e.PropertyName == nameof(simulationService.CurrentDate))
-                    UpdatePie();
-            };
-            UpdatePie();
+            Options = new PieOptions();
             view.PieModels = PieModels;
+
+            Options.PropertyChanged += (_, __) => Debounce();
+            rebuildTimer.Elapsed += (_, __) => RebuildAll();
         }
 
-        private OxyColor GetColor(string name)
+        public void SetBlocks(IEnumerable<Block> source)
         {
-            if (!colorMap.ContainsKey(name))
-                colorMap[name] = palette[colorMap.Count % palette.Length];
-            return colorMap[name];
+            blocks.Clear();
+            if (source != null)
+                blocks.AddRange(source);
+            Debounce();
         }
 
-        private void UpdatePie()
+        public void RebuildAll()
         {
+            rebuildTimer.Stop();
             PieModels.Clear();
-            var blocks = scheduleService.GetAllBlocks().ToList();
-            if (!blocks.Any()) return;
-
-            var currentDate = simulationService.CurrentDate;
-
             for (int wp = 1; wp <= 6; wp++)
             {
-                var wsBlocks = blocks.Where(b => b.DeployWorkplace == wp).ToList();
-                if (!wsBlocks.Any())
-                {
-                    var emptyModel = new PlotModel { Title = $"작업장 {wp}" };
-                    var emptySeries = new PieSeries
-                    {
-                        StrokeThickness = 0.5,
-                        InsideLabelPosition = 0.5,
-                        AngleSpan = 360,
-                        StartAngle = 0
-                    };
-                    emptySeries.Slices.Add(new PieSlice("미사용", 1) { Fill = OxyColors.LightGray });
-                    emptyModel.Series.Add(emptySeries);
-                    PieModels.Add(emptyModel);
-                    continue;
-                }
-
-                var wsStart = wsBlocks.Min(b => b.Start);
-                var wsEnd = wsBlocks.Max(b => b.End);
-                var end = currentDate < wsEnd ? currentDate : wsEnd;
-                double totalDays = (end - wsStart).TotalDays;
-
-                var model = new PlotModel { Title = $"작업장 {wp}" };
-                var series = new PieSeries
-                {
-                    StrokeThickness = 0.5,
-                    InsideLabelPosition = 0.5,
-                    AngleSpan = 360,
-                    StartAngle = 0
-                };
-
-                double usedSum = 0;
-                foreach (var b in wsBlocks.OrderBy(b => b.Start))
-                {
-                    if (b.Start >= end) break;
-                    var useStart = b.Start < wsStart ? wsStart : b.Start;
-                    var useEnd = b.End < end ? b.End : end;
-                    double days = Math.Max(0, (useEnd - useStart).TotalDays);
-                    if (days <= 0) continue;
-                    usedSum += days;
-
-                    var color = GetColor(b.Name);
-
-                    series.Slices.Add(new PieSlice(b.Name, days) { Fill = color });
-                }
-
-                var idle = Math.Max(0, totalDays - usedSum);
-                if (idle > 0)
-                {
-                    series.Slices.Add(new PieSlice("미사용", idle)
-                    {
-                        Fill = OxyColors.LightGray
-                    });
-                }
-
-                model.Series.Add(series);
-                PieModels.Add(model);
+                PieModels.Add(BuildModel(wp));
             }
+        }
+
+        private PlotModel BuildModel(int workplace)
+        {
+            var items = blocks.Where(b => b.DeployWorkplace == workplace)
+                .GroupBy(b => string.IsNullOrWhiteSpace(b.Name) ? "Unknown" : b.Name)
+                .Select(g => new NameVal { Name = g.Key, Val = g.Sum(b => Math.Max((b.End - b.Start).TotalHours, 0)) })
+                .Where(nv => nv.Val > 0)
+                .OrderByDescending(nv => nv.Val)
+                .ToList();
+
+            double total = items.Sum(i => i.Val);
+            var model = new PlotModel { Title = $"작업장 {workplace}" };
+            model.Legends.Add(new Legend { LegendPosition = LegendPosition.RightTop });
+            if (total <= 0)
+                return model;
+
+            if (Options.UseBarChart)
+                BuildBarChart(model, items, total);
+            else
+                BuildPieChart(model, items, total);
+            return model;
+        }
+
+        private void BuildPieChart(PlotModel model, List<NameVal> items, double total)
+        {
+            var keep = new List<NameVal>();
+            double others = 0;
+            foreach (var x in items)
+            {
+                if (x.Val / total < Options.SmallSliceThreshold) others += x.Val;
+                else keep.Add(x);
+            }
+            while (keep.Count > Options.MaxSlices)
+            {
+                var last = keep[keep.Count - 1];
+                keep.RemoveAt(keep.Count - 1);
+                others += last.Val;
+            }
+            if (others > 0)
+                keep.Add(new NameVal { Name = "기타", Val = others });
+
+            var series = new PieSeries
+            {
+                StartAngle = 180,
+                AngleSpan = 360,
+                InnerDiameter = Options.InnerDiameter,
+                InsideLabelPosition = 0.7,
+                InsideLabelFormat = Options.LabelMode == LabelMode.PercentOnly ? "{2:0.#}%" : null,
+                OutsideLabelFormat = null,
+                Stroke = OxyColors.White,
+                StrokeThickness = 1,
+                TickHorizontalLength = 0,
+                TickRadialLength = 0,
+                LegendFormat = "{0}",
+                TrackerFormatString = "{0}: {2:0.#}% ({1:0.#})"
+            };
+
+            int index = 0;
+            foreach (var k in keep)
+            {
+                var color = BlockColorMap.GetColor(k.Name).ToOxyColor();
+                var slice = new PieSlice(k.Name, k.Val) { Fill = color };
+                slice.TextColor = index < Options.TopN ? OxyColors.Black : OxyColors.Transparent;
+                series.Slices.Add(slice);
+                index++;
+            }
+            model.Series.Add(series);
+        }
+
+        private void BuildBarChart(PlotModel model, List<NameVal> items, double total)
+        {
+            var top = items.Take(Options.TopN).ToList();
+            var categoryAxis = new CategoryAxis { Position = AxisPosition.Left };
+            foreach (var item in top)
+                categoryAxis.Labels.Add(Shorten(item.Name));
+            model.Axes.Add(categoryAxis);
+            model.Axes.Add(new LinearAxis { Position = AxisPosition.Bottom, Minimum = 0, Maximum = 100, MajorStep = 10 });
+
+            int idx = 0;
+            foreach (var item in top)
+            {
+                var color = BlockColorMap.GetColor(item.Name).ToOxyColor();
+                var bar = new BarSeries
+                {
+                    Title = item.Name,
+                    FillColor = color,
+                    TrackerFormatString = "{0}: {1:0.#}%"
+                };
+                bar.Items.Add(new BarItem(item.Val / total * 100) { CategoryIndex = idx });
+                model.Series.Add(bar);
+                idx++;
+            }
+        }
+
+        private static string Shorten(string name)
+        {
+            if (string.IsNullOrWhiteSpace(name)) return "Unknown";
+            string noParen = Regex.Replace(name, "\([^)]*\)", "");
+            string normalized = Regex.Replace(noParen, "\s+", " ").Trim();
+            return normalized.Length > 12 ? normalized.Substring(0, 12) + "…" : normalized;
+        }
+
+        private void Debounce()
+        {
+            rebuildTimer.Stop();
+            rebuildTimer.Start();
+        }
+
+        private class NameVal
+        {
+            public string Name { get; set; }
+            public double Val { get; set; }
         }
     }
 }

--- a/BlockViz.Presentation/Views/PiView.xaml
+++ b/BlockViz.Presentation/Views/PiView.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Class="BlockViz.Presentation.Views.PiView"
+<UserControl x:Class="BlockViz.Presentation.Views.PiView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:oxy="http://oxyplot.org/wpf">
@@ -18,8 +18,7 @@
             <ItemsControl.ItemTemplate>
                 <DataTemplate>
                     <oxy:PlotView Model="{Binding}"
-                                  Width="120" Height="120"
-                                  Margin="4"/>
+                                  Margin="8,0,16,0"/>
                 </DataTemplate>
             </ItemsControl.ItemTemplate>
         </ItemsControl>


### PR DESCRIPTION
## Summary
- Add configurable PieOptions with thresholds, slice limits, label modes and bar toggle
- Convert application colors to OxyPlot colors via extension method
- Rebuild PiViewModel to group small slices, support Top-N labeling and optional bar charts
- Adjust PiView layout to provide space for legends

## Testing
- `dotnet build` *(fails: dotnet: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6899b0d047a48321aee96fb4eb1dcc44